### PR TITLE
Revert "marlin: Enforce privapp-permissions whitelist"

### DIFF
--- a/device-common.mk
+++ b/device-common.mk
@@ -29,10 +29,6 @@ PRODUCT_SHIPPING_API_LEVEL := 25
 # Setting vendor SPL
 VENDOR_SECURITY_PATCH := "2019-08-01"
 
-# Enforce privapp-permissions whitelist
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.control_privapp_permissions=enforce
-
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.software.verified_boot.xml:system/etc/permissions/android.software.verified_boot.xml
 


### PR DESCRIPTION
This reverts commit 897394a9188c6dc320682e1cfa2a35ae4ee79b50.

Reason for revert: It's enforced globally now.

Change-Id: I34ff70c0c209f85affa8ef837474ad48873c6876